### PR TITLE
Revised the packageSourUrl repository URL to lowercase

### DIFF
--- a/geforce-experience/geforce-experience.nuspec
+++ b/geforce-experience/geforce-experience.nuspec
@@ -19,7 +19,7 @@ GeForce ShadowPlay™ is the easiest way to capture your favourite gaming moment
 GeForce Experience streams your PC games to the NVIDIA SHIELD gaming portable, so you can play your favourite games around the house or on the go. Jump into Borderlands 2 without getting out of bed. Or pick up where you left off in Skyrim at the local cafe.
     </description>
     <projectUrl>http://www.geforce.com/geforce-experience</projectUrl>
-    <packageSourceUrl>https://github.com/AeliusSaionji/chocopkgs/tree/master/GeForce-Experience</packageSourceUrl>
+    <packageSourceUrl>https://github.com/AeliusSaionji/chocopkgs/tree/master/geforce-experience</packageSourceUrl>
     <!--<projectSourceUrl></projectSourceUrl>
     <docsUrl></docsUrl>
     <mailingListUrl></mailingListUrl>


### PR DESCRIPTION
I discovered that the Package Source link for the GeForce Experience package in Chocolatey resolved to a 401 error.  It appears that the packageSourceUrl value in the nuspec had capital letters, perhaps based off of a previous name for the project.  I have corrected the URL and tested that it resolves to your project's page within GitHub properly.  The next submission to Chocolatey should then fix the link on their site.