### PR TITLE
Update latencymon checksum

### DIFF
--- a/latencymon/tools/chocolateyinstall.ps1
+++ b/latencymon/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@
   fileType = 'EXE'
   SilentArgs = '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
   url = 'http://www.resplendence.com/download/LatencyMon.exe'
-  checksum = 'e6c8fe0d2b4b03566e40a5e7a4474108f23df2f3709d677f8d925c7d858e5082'
+  checksum = '77e90f0f042f9806639de25c67fa78948696cb635c8f47c4f11e92cd6162a2ae'
   checksumType = 'SHA256'
 }
 


### PR DESCRIPTION
The checksum has changed but the version number is still 7.00 (build 700.31110)