### PR TITLE
Fix warnings on running .bat scripts

### DIFF
--- a/mpv.install/tools/chocolateyinstall.ps1
+++ b/mpv.install/tools/chocolateyinstall.ps1
@@ -18,7 +18,7 @@ Get-ChocolateyUnzip @packageArgs
 Get-ChocolateyUnzip -file "$toolsDir\rossy.zip" -destination $toolsDir
 Move-Item "$toolsDir\mpv-install-master\*" $toolsDir -Force
 Remove-Item "$toolsDir\mpv-install-master"
-Start-ChocolateyProcessAsAdmin -Statements "/K $toolsDir\mpv-install.bat /u" -ExeToRun 'cmd.exe' -Elevated -validExitCodes '0'
+Start-ChocolateyProcessAsAdmin -Statements "/K $toolsDir\mpv-install.bat /u" -ExeToRun "$env:SystemRoot\System32\cmd.exe" -Elevated -validExitCodes '0'
 Remove-Item -force "$toolsDir\*.zip","$toolsDir\*.7z" -ea 0
 
 # mpv can't be shimmed, the shim doesn't work with mpv.com

--- a/mpv.install/tools/chocolateyuninstall.ps1
+++ b/mpv.install/tools/chocolateyuninstall.ps1
@@ -14,4 +14,4 @@ if ( $userPath.Contains($toolsDir) ) {
 	 [Environment]::SetEnvironmentVariable("PATH", "$cleanUserPath", [EnvironmentVariableTarget]::User)
 }
 	
-Start-ChocolateyProcessAsAdmin "/K $toolsDir\mpv-uninstall.bat /u" 'cmd.exe' -validExitCodes '0'
+Start-ChocolateyProcessAsAdmin "/K $toolsDir\mpv-uninstall.bat /u" "$env:SystemRoot\System32\cmd.exe" -validExitCodes '0'


### PR DESCRIPTION
Installation throws warnings in PS 5.1 "WARNING: May not be able to find 'cmd.exe'. Please use full path for executables.". Following changes should fix it.