### PR TITLE
Updated geforce-game-ready-driver to use DCH by default

### DIFF
--- a/geforce-game-ready-driver/tools/chocolateyInstall.ps1
+++ b/geforce-game-ready-driver/tools/chocolateyInstall.ps1
@@ -2,8 +2,8 @@
 $packageArgs = @{
   packageName    = 'geforce-game-ready-driver'
   fileType       = 'EXE'
-  url64          = 'https://us.download.nvidia.com/Windows/472.12/472.12-desktop-win10-win11-64bit-international-whql.exe'
-  checksum64     = '95d8dc470e8f1352b4dbc3b38aefeb5cbbba024826a0541a9f88501b642d81d3'
+  url64          = 'https://us.download.nvidia.com/Windows/511.23/511.23-desktop-win10-win11-64bit-international-dch-whql.exe'
+  checksum64     = 'a315d817a37a53875eca63963b9a8a5f1836e236e8494aa9df6474059a10d603'
   checksumType64 = 'sha256'
   silentArgs     = '-s -noreboot'
   validExitCodes = @(0,1)
@@ -13,14 +13,6 @@ $packageArgs = @{
 If ( [System.Environment]::OSVersion.Version.Major -ne '10' ) {
   $packageArgs['url64']      = 'https://us.download.nvidia.com/Windows/472.12/472.12-desktop-win8-win7-64bit-international-whql.exe'
   $packageArgs['checksum64'] = 'a4b182d13d3de60c5ed4bbd59122345c9bde159f95b3e92c2954ea4e83c13740'
-}
-
-$pp = Get-PackageParameters
-If ($pp['dch'] -eq 'true') {
-  $packageArgsDCHURL      = 'https://us.download.nvidia.com/Windows/511.23/511.23-desktop-win10-win11-64bit-international-dch-whql.exe'
-  $packageArgsDCHChecksum = 'a315d817a37a53875eca63963b9a8a5f1836e236e8494aa9df6474059a10d603'
-  $packageArgs['url64']      = $packageArgsDCHURL
-  $packageArgs['checksum64'] = $packageArgsDCHChecksum
 }
 
 If ( -not (Get-OSArchitectureWidth -compare 64) ) {
@@ -33,4 +25,3 @@ If ( -not (Get-OSArchitectureWidth -compare 64) ) {
 Install-ChocolateyPackage @packageArgs
 
 Write-Host "The package 'nvidia-display-driver' is also available for those who don't want or need the extra software bundled with the conventional geforce package."
-Write-Host "Nvidia website is funneling users towards the DCH download of their drivers. DCH is a new driver format, Win10+Win11 users should consider using the chocolatey package parameter to install the DCH version. See this package's page on chocolatey for details."

--- a/geforce-game-ready-driver/update.ps1
+++ b/geforce-game-ready-driver/update.ps1
@@ -1,19 +1,16 @@
 ﻿Import-Module au
 
 $releasesDCH = 'https://gfwsl.geforce.com/services_toolkit/services/com/nvidia/services/AjaxDriverService.php?func=DriverManualLookup&psid=98&osID=57&languageCode=1033&beta=0&isWHQL=1&dltype=-1&dch=1&upCRD=0&sort1=0&numberOfResults=1'
-$releases1064 = 'https://gfwsl.geforce.com/services_toolkit/services/com/nvidia/services/AjaxDriverService.php?func=DriverManualLookup&psid=98&osID=57&languageCode=1033&beta=0&isWHQL=1&dltype=-1&dch=0&upCRD=0&sort1=0&numberOfResults=1'
 $releases7864 = 'https://gfwsl.geforce.com/services_toolkit/services/com/nvidia/services/AjaxDriverService.php?func=DriverManualLookup&psid=98&osID=19&languageCode=1033&beta=0&isWHQL=1&dltype=-1&dch=0&upCRD=0&sort1=0&numberOfResults=1'
 
 function global:au_SearchReplace {
   @{
     ".\tools\chocolateyInstall.ps1" = @{
-      "(?i)(^\s*url64\s*=\s*)('.*')"                          = "`$1'$($Latest.URL1064)'"
+      "(?i)(^\s*url64\s*=\s*)('.*')"                          = "`$1'$($Latest.URLDCH)'"
       "(?i)(^\s*checksumType64\s*=\s*)('.*')"                 = "`$1'$($Latest.ChecksumType64)'"
-      "(?i)(^\s*checksum64\s*=\s*)('.*')"                     = "`$1'$($Latest.Checksum1064)'"
+      "(?i)(^\s*checksum64\s*=\s*)('.*')"                     = "`$1'$($Latest.ChecksumDCH)'"
       "(?i)(^\s*[$]packageArgs\['url64'\]\s*=\s*)('.*')"      = "`$1'$($Latest.URL7864)'"
       "(?i)(^\s*[$]packageArgs\['checksum64'\]\s*=\s*)('.*')" = "`$1'$($Latest.Checksum7864)'"
-      "(?i)(^\s*[$]packageArgsDCHURL\s*=\s*)('.*')"           = "`$1'$($Latest.URLDCH)'"
-      "(?i)(^\s*[$]packageArgsDCHChecksum\s*=\s*)('.*')"      = "`$1'$($Latest.ChecksumDCH)'"
     }
     ".\geforce-game-ready-driver.nuspec" = @{
       "(?i)(^\s*<releaseNotes>)(.*)" = "`${1}https://us.download.nvidia.com/Windows/$($Latest.Version)/$($Latest.Version)-win11-win10-win8-win7-release-notes.pdf</releaseNotes>"
@@ -23,11 +20,10 @@ function global:au_SearchReplace {
 
 function global:au_BeforeUpdate {
   $Latest.ChecksumType64 = "sha256"
-  $Latest.Checksum1064 = Get-RemoteChecksum -Url $Latest.URL1064
   $Latest.Checksum7864 = Get-RemoteChecksum -Url $Latest.URL7864
   $Latest.ChecksumDCH  = Get-RemoteChecksum -Url $Latest.URLDCH
   # export checksums for use with other package
-  sc ..\knownChecksums "$Latest.Checksum1064`n$Latest.Checksum7864`n$Latest.ChecksumDCH"
+  sc ..\knownChecksums "$Latest.Checksum7864`n$Latest.ChecksumDCH"
 }
 
 function global:au_GetLatest {
@@ -37,29 +33,24 @@ function global:au_GetLatest {
     function global:au_BeforeUpdate {
       $knownChecksums = gc ..\knownChecksums
       $Latest.ChecksumType64 = "sha256"
-      $Latest.Checksum1064 = $knownChecksums[0]
-      $Latest.Checksum7864 = $knownChecksums[1]
-      $Latest.ChecksumDCH  = $knownChecksums[2]
+      $Latest.Checksum7864 = $knownChecksums[0]
+      $Latest.ChecksumDCH  = $knownChecksums[1]
       rm ..\knownChecksums
     }
   }
   $restDCH  = Invoke-RestMethod $releasesDCH -UseBasicParsing
-  $rest1064 = Invoke-RestMethod $releases1064 -UseBasicParsing
   $rest7864 = Invoke-RestMethod $releases7864 -UseBasicParsing
   $version  = $restDCH.IDS[0].downloadInfo.Version
   $urlDCH   = $restDCH.IDS[0].downloadInfo.DownloadURL
-  $url1064  = $rest1064.IDS[0].downloadInfo.DownloadURL
   $url7864  = $rest7864.IDS[0].downloadInfo.DownloadURL
   # Unfortunately I can't think of a clean way to detect -rp just once. The code below releases a new version every time an update is checked for...
   # if (iwr -Method Head "https://us.download.nvidia.com/Windows/$version/$version-desktop-win10-64bit-international-whql-rp.exe") {
-  #   $url1064 = "https://us.download.nvidia.com/Windows/$version/$version-desktop-win10-64bit-international-whql-rp.exe"
   #   $url7864 = "https://us.download.nvidia.com/Windows/$version/$version-desktop-win8-win7-64bit-international-whql-rp.exe"
   #   $version = $Matches[0] + ".0.$(Get-Date -Format yyyyMMdd)"
   # }
   return @{
     Version = $version
     URLDCH  = $urlDCH
-    URL1064 = $url1064
     URL7864 = $url7864
   }
 }


### PR DESCRIPTION
Updated `geforce-game-ready-driver` to use DCH by default as the non-DCH is not being updated anymore.