### PR TITLE
Add NVPCF as required component

### DIFF
--- a/nvidia-display-driver/tools/chocolateyInstall.ps1
+++ b/nvidia-display-driver/tools/chocolateyInstall.ps1
@@ -39,6 +39,7 @@ Get-ChocolateyUnzip @packageArgs
 Move-Item ($packageArgs['destination'] + "\Display.Driver"        ) -Destination "$instDir"
 Move-Item ($packageArgs['destination'] + "\Display.Optimus"       ) -Destination "$instDir"
 Move-Item ($packageArgs['destination'] + "\NVI2"                  ) -Destination "$instDir"
+Move-Item ($packageArgs['destination'] + "\NVPCF"                 ) -Destination "$instDir"
 Move-Item ($packageArgs['destination'] + "\PhysX"                 ) -Destination "$instDir"
 Move-Item ($packageArgs['destination'] + "\EULA.txt"              ) -Destination "$instDir"
 Move-Item ($packageArgs['destination'] + "\ListDevices.txt"       ) -Destination "$instDir"


### PR DESCRIPTION
On my RTX 3060 (Notebook) GPU, this seems to be required for the "NVIDIA Platform Controllers and Framework" device in Device Manager. Normally with  `geforce-game-ready-driver`, this is automatically installed for my system since it's referenced by `Display.Driver`'s INF files (via `nvpcf.inf`).

I haven't done extensive testing myself, but some rough research shows it's required by Dynamic Boost 2.0, and seems to affect the maximum performance of the card, battery performance, and thermals. References:

* https://www.nvidia.com/en-us/geforce/forums/geforce-laptops/6/398641/nvidia-platform-controllers-and-framework-code-3/3080182/
* https://www.reddit.com/r/eluktronics/comments/13vsskr/psa_nvidia_platform_controllers_and_framework/