### PR TITLE
Fix qutebrowser

### DIFF
--- a/qutebrowser.install/qutebrowser.install.nuspec
+++ b/qutebrowser.install/qutebrowser.install.nuspec
@@ -4,26 +4,26 @@
   <metadata>
     <id>qutebrowser.install</id>
     <title>qutebrowser (Install)</title>
-    <version>2.5.3</version>
-    <authors>The-Compiler</authors>
+    <version>3.1.0</version>
+    <authors>qutebrowser</authors>
     <owners>LinkSatonaka</owners>
     <summary>A keyboard-driven, vim-like browser based on PyQt5 and QtWebKit.</summary>
     <description>qutebrowser is a keyboard-focused browser with a minimal GUI. It’s based on Python, PyQt5 and QtWebKit and free software, licensed under the GPL.
 	    It was inspired by other browsers/addons like dwb and Vimperator/Pentadactyl.</description>
-    <projectUrl>https://github.com/The-Compiler/qutebrowser</projectUrl>
+    <projectUrl>https://github.com/qutebrowser/qutebrowser</projectUrl>
     <packageSourceUrl>https://github.com/AeliusSaionji/chocopkgs/tree/master/qutebrowser.install</packageSourceUrl>
-    <projectSourceUrl>https://github.com/The-Compiler/qutebrowser</projectSourceUrl>
-    <docsUrl>https://github.com/The-Compiler/qutebrowser#documentation</docsUrl>
-    <bugTrackerUrl>https://github.com/The-Compiler/qutebrowser/issues</bugTrackerUrl>
+    <projectSourceUrl>https://github.com/qutebrowser/qutebrowser</projectSourceUrl>
+    <docsUrl>https://github.com/qutebrowser/qutebrowser#documentation</docsUrl>
+    <bugTrackerUrl>https://github.com/qutebrowser/qutebrowser/issues</bugTrackerUrl>
     <tags>qutebrowser admin browser</tags>
     <copyright></copyright>
-    <licenseUrl>https://github.com/The-Compiler/qutebrowser#license</licenseUrl>
+    <licenseUrl>https://github.com/qutebrowser/qutebrowser#license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/Link-Satonaka/chocopkgs/fa147cc79a1473cf349877ccbbeb85105af5c298/qutebrowser.png</iconUrl>
     <dependencies>
       <dependency id="vcredist140" />
     </dependencies>
-    <releaseNotes>https://github.com/The-Compiler/qutebrowser/releases</releaseNotes>
+    <releaseNotes>https://github.com/qutebrowser/qutebrowser/releases</releaseNotes>
     <provides>qutebrowser</provides>
   </metadata>
   <files>

--- a/qutebrowser.install/tools/VERIFICATION.txt
+++ b/qutebrowser.install/tools/VERIFICATION.txt
@@ -8,8 +8,7 @@ and can be verified by doing the following:
 
 1. Go to
 
-	x32: https://github.com/qutebrowser/qutebrowser/releases/download/v2.5.3/qutebrowser-2.5.3-win32.exe
-	x64: https://github.com/qutebrowser/qutebrowser/releases/download/v2.5.3/qutebrowser-2.5.3-amd64.exe
+	x64: https://github.com/qutebrowser/qutebrowser/releases/download/v3.1.0/qutebrowser-3.1.0-amd64.exe
 
 	to download the installer.
 
@@ -20,7 +19,6 @@ and can be verified by doing the following:
 3. The checksums should match the following:
 
   checksumType: sha256
-  checksum32: DC09471FAD135946319FDC6D254A5B5CD225E9052605D82E77CF93216458FD5A
-  checksum64: 2BC743F17AE9B2BD6804A463BE5587CD2ECE7BC57C7B3B429CE0EFD7F8CBC450
+  checksum64: 7259DAC438F421BFABF34CC92F5FF7CF9FC639B3518A411B98393C81FA7C0E67
 
 The file 'LICENSE.txt' has been obtained from <https://github.com/qutebrowser/qutebrowser/blob/master/LICENSE>.

--- a/qutebrowser.install/tools/chocolateyinstall.ps1
+++ b/qutebrowser.install/tools/chocolateyinstall.ps1
@@ -4,11 +4,9 @@ $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $packageArgs = @{
 	packageName = 'qutebrowser.install'
 	fileType    = 'exe'
-	file32      = "$toolsdir\qutebrowser-2.5.3-win32_x32.exe"
-	file64      = "$toolsdir\qutebrowser-2.5.3-amd64_x64.exe"
+	file64      = "$toolsdir\qutebrowser-3.1.0-amd64_x64.exe"
 	silentArgs  = '/S /allusers'
 }
 
 Install-ChocolateyInstallPackage @packageArgs
-Remove-Item $packageArgs.file32 -Force -ea 0
 Remove-Item $packageArgs.file64 -Force -ea 0

--- a/qutebrowser.install/update.ps1
+++ b/qutebrowser.install/update.ps1
@@ -9,14 +9,11 @@ $headers = @{
 function global:au_SearchReplace {
 	@{
 		".\tools\VERIFICATION.txt" = @{
-			"(?i)(\s+x32:).*"                   = "`${1} $($Latest.URL32)"
 			"(?i)(\s+x64:).*"                   = "`${1} $($Latest.URL64)"
 			"(?i)(^\s*checksum\s*type\:).*"     = "`${1} $($Latest.ChecksumType64)"
-			"(?i)(^\s*checksum32\:).*"          = "`${1} $($Latest.Checksum32)"
 			"(?i)(^\s*checksum64\:).*"          = "`${1} $($Latest.Checksum64)"
 		}
     ".\tools\chocolateyinstall.ps1" = @{
-      "(?i)(\s+file32\s+=).*"          = "`${1} `"`$toolsdir\$($Latest.FileName32)`""
       "(?i)(\s+file64\s+=).*"          = "`${1} `"`$toolsdir\$($Latest.FileName64)`""
     }
 	}
@@ -31,14 +28,11 @@ function global:au_GetLatest {
   $Matches = $null
   $restAPI.tag_name -match '(\d+\.?)+'
   $version = $Matches[0]
-  $url32 = $restAPI.assets | Where-Object { ($_.content_type -eq 'application/vnd.microsoft.portable-executable') `
-    -and ($_.name -like '*win32*') } `
-    | Select-Object -First 1 -ExpandProperty browser_download_url
   $url64 = $restAPI.assets | Where-Object { ($_.content_type -eq 'application/vnd.microsoft.portable-executable') `
     -and ($_.name -like '*amd64*') } `
     | Select-Object -First 1 -ExpandProperty browser_download_url
 
-  return @{ Version = $version; URL32 = $url32; URL64 = $url64; }
+  return @{ Version = $version; URL64 = $url64; }
 }
 
 if ($MyInvocation.InvocationName -ne '.') { # run the update only if script is not sourced

--- a/qutebrowser.portable/qutebrowser.portable.nuspec
+++ b/qutebrowser.portable/qutebrowser.portable.nuspec
@@ -4,26 +4,26 @@
   <metadata>
     <id>qutebrowser.portable</id>
     <title>qutebrowser (Portable)</title>
-    <version>2.1.1</version>
-    <authors>The-Compiler</authors>
+    <version>3.1.0</version>
+    <authors>qutebrowser</authors>
     <owners>LinkSatonaka</owners>
     <summary>A keyboard-driven, vim-like browser based on PyQt5 and QtWebKit.</summary>
     <description>qutebrowser is a keyboard-focused browser with a minimal GUI. It’s based on Python, PyQt5 and QtWebKit and free software, licensed under the GPL.
 	    It was inspired by other browsers/addons like dwb and Vimperator/Pentadactyl.</description>
-    <projectUrl>https://github.com/The-Compiler/qutebrowser</projectUrl>
+    <projectUrl>https://github.com/qutebrowser/qutebrowser</projectUrl>
     <packageSourceUrl>https://github.com/AeliusSaionji/chocopkgs/tree/master/qutebrowser.portable</packageSourceUrl>
-    <projectSourceUrl>https://github.com/The-Compiler/qutebrowser</projectSourceUrl>
-    <docsUrl>https://github.com/The-Compiler/qutebrowser#documentation</docsUrl>
-    <bugTrackerUrl>https://github.com/The-Compiler/qutebrowser/issues</bugTrackerUrl>
+    <projectSourceUrl>https://github.com/qutebrowser/qutebrowser</projectSourceUrl>
+    <docsUrl>https://github.com/qutebrowser/qutebrowser#documentation</docsUrl>
+    <bugTrackerUrl>https://github.com/qutebrowser/qutebrowser/issues</bugTrackerUrl>
     <tags>qutebrowser browser</tags>
     <copyright></copyright>
-    <licenseUrl>https://github.com/The-Compiler/qutebrowser#license</licenseUrl>
+    <licenseUrl>https://github.com/qutebrowser/qutebrowser#license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/Link-Satonaka/chocopkgs/fa147cc79a1473cf349877ccbbeb85105af5c298/qutebrowser.png</iconUrl>
     <dependencies>
       <dependency id="vcredist140" />
     </dependencies>
-    <releaseNotes>https://github.com/The-Compiler/qutebrowser/releases</releaseNotes>
+    <releaseNotes>https://github.com/qutebrowser/qutebrowser/releases</releaseNotes>
     <provides>qutebrowser</provides>
   </metadata>
   <files>

--- a/qutebrowser.portable/tools/VERIFICATION.txt
+++ b/qutebrowser.portable/tools/VERIFICATION.txt
@@ -8,8 +8,7 @@ and can be verified by doing the following:
 
 1. Go to
 
-	x32: https://github.com/qutebrowser/qutebrowser/releases/download/v2.1.1/qutebrowser-2.1.1-windows-standalone-win32.zip
-	x64: https://github.com/qutebrowser/qutebrowser/releases/download/v2.1.1/qutebrowser-2.1.1-windows-standalone-amd64.zip
+	x64: https://github.com/qutebrowser/qutebrowser/releases/download/v3.1.0/qutebrowser-3.1.0-windows-standalone.zip
 
 	to download the installer.
 
@@ -20,7 +19,6 @@ and can be verified by doing the following:
 3. The checksums should match the following:
 
   checksumType: sha256
-  checksum32: 03614CBA38607BAB7F34D4DFDA4486E2318A64D2FDFDCEF4BBC01EB840419727
-  checksum64: 3398868A7E093A69DD306EEF9989821CE97EF3E58B92ED716D2DB8AD02DECDD5
+  checksum64: A95EA52EA4F9B01939CC3AF783C9C15D006D3FB4D1FBE0264A6D4D4FFB494168
 
 The file 'LICENSE.txt' has been obtained from <https://github.com/qutebrowser/qutebrowser/blob/master/LICENSE>.

--- a/qutebrowser.portable/tools/chocolateyinstall.ps1
+++ b/qutebrowser.portable/tools/chocolateyinstall.ps1
@@ -12,11 +12,9 @@ Get-ChildItem -Directory $toolsDir\qutebrowser* | Remove-Item -Force -ea 0
 
 $packageArgs = @{
   packageName = 'qutebrowser.portable'
-  file32      = "$toolsdir\qutebrowser-2.1.1-windows-standalone-win32_x32.zip"
-  file64      = "$toolsdir\qutebrowser-2.1.1-windows-standalone-amd64_x64.zip"
+  file64      = "$toolsdir\qutebrowser-3.1.0-windows-standalone_x64.zip"
   destination = "$toolsDir"
 }
 
 Get-ChocolateyUnzip @packageArgs
-Remove-Item $packageArgs.file32 -Force -ea 0
 Remove-Item $packageArgs.file64 -Force -ea 0

--- a/qutebrowser.portable/update.ps1
+++ b/qutebrowser.portable/update.ps1
@@ -9,14 +9,11 @@ $headers = @{
 function global:au_SearchReplace {
   @{
     ".\tools\VERIFICATION.txt" = @{
-      "(?i)(\s+x32:).*"                   = "`${1} $($Latest.URL32)"
       "(?i)(\s+x64:).*"                   = "`${1} $($Latest.URL64)"
       "(?i)(^\s*checksum\s*type\:).*"     = "`${1} $($Latest.ChecksumType64)"
-      "(?i)(^\s*checksum32\:).*"          = "`${1} $($Latest.Checksum32)"
       "(?i)(^\s*checksum64\:).*"          = "`${1} $($Latest.Checksum64)"
     }
     ".\tools\chocolateyinstall.ps1" = @{
-      "(?i)(\s+file32\s+=).*"          = "`${1} `"`$toolsdir\$($Latest.FileName32)`""
       "(?i)(\s+file64\s+=).*"          = "`${1} `"`$toolsdir\$($Latest.FileName64)`""
     }
   }
@@ -31,14 +28,11 @@ function global:au_GetLatest {
   $Matches = $null
   $restAPI.tag_name -match '(\d+\.?)+'
   $version = $Matches[0]
-  $url32 = $restAPI.assets | Where-Object { ($_.content_type -eq 'application/zip') `
-    -and ($_.name -like '*win32*') } `
-    | Select-Object -First 1 -ExpandProperty browser_download_url
   $url64 = $restAPI.assets | Where-Object { ($_.content_type -eq 'application/zip') `
-    -and ($_.name -like '*amd64*') } `
+    -and ($_.name -like '*windows-standalone*') } `
     | Select-Object -First 1 -ExpandProperty browser_download_url
 
-  return @{ Version = $version; URL32 = $url32; URL64 = $url64; }
+  return @{ Version = $version; URL64 = $url64; }
 }
 
 Update-Package -checksumfor none

--- a/qutebrowser/qutebrowser.nuspec
+++ b/qutebrowser/qutebrowser.nuspec
@@ -4,26 +4,26 @@
   <metadata>
     <id>qutebrowser</id>
     <title>qutebrowser</title>
-    <version>2.5.3</version>
-    <authors>The-Compiler</authors>
+    <version>3.1.0</version>
+    <authors>qutebrowser</authors>
     <owners>LinkSatonaka</owners>
     <summary>A keyboard-driven, vim-like browser based on PyQt5 and QtWebKit.</summary>
     <description>qutebrowser is a keyboard-focused browser with a minimal GUI. It’s based on Python, PyQt5 and QtWebKit and free software, licensed under the GPL.
 	    It was inspired by other browsers/addons like dwb and Vimperator/Pentadactyl.</description>
-    <projectUrl>https://github.com/The-Compiler/qutebrowser</projectUrl>
+    <projectUrl>https://github.com/qutebrowser/qutebrowser</projectUrl>
     <packageSourceUrl>https://github.com/Link-Satonaka/chocopkgs/tree/master/qutebrowser</packageSourceUrl>
-    <projectSourceUrl>https://github.com/The-Compiler/qutebrowser</projectSourceUrl>
-    <docsUrl>https://github.com/The-Compiler/qutebrowser#documentation</docsUrl>
-    <bugTrackerUrl>https://github.com/The-Compiler/qutebrowser/issues</bugTrackerUrl>
+    <projectSourceUrl>https://github.com/qutebrowser/qutebrowser</projectSourceUrl>
+    <docsUrl>https://github.com/qutebrowser/qutebrowser#documentation</docsUrl>
+    <bugTrackerUrl>https://github.com/qutebrowser/qutebrowser/issues</bugTrackerUrl>
     <tags>qutebrowser browser</tags>
     <copyright></copyright>
-    <licenseUrl>https://github.com/The-Compiler/qutebrowser#license</licenseUrl>
+    <licenseUrl>https://github.com/qutebrowser/qutebrowser#license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/Link-Satonaka/chocopkgs/fa147cc79a1473cf349877ccbbeb85105af5c298/qutebrowser.png</iconUrl>
     <dependencies>
-      <dependency id="qutebrowser.install" version="2.5.3" />
+      <dependency id="qutebrowser.install" version="3.1.0" />
     </dependencies>
-    <releaseNotes>https://github.com/The-Compiler/qutebrowser/releases</releaseNotes>
+    <releaseNotes>https://github.com/qutebrowser/qutebrowser/releases</releaseNotes>
     <provides></provides>
   </metadata>
   <files>


### PR DESCRIPTION
Upstream developer changed the project URL to https://github.com/qutebrowser/qutebrowser

They also dropped support for 32 bits installers/binaries.

This PR fix those issues.