### PR TITLE
fix: fix failing chocolateyInstall.ps1 for nvidia-display-driver package

### DIFF
--- a/nvidia-display-driver/nvidia-display-driver.nuspec
+++ b/nvidia-display-driver/nvidia-display-driver.nuspec
@@ -31,8 +31,8 @@ The following package parameters can be set to enable optional components:
  * `/ShadowPlay` - Install ShadowPlay.
  * `/FrameView` - Install FrameView.
  * `/MSVCRT` - Install the nvidia-packaged 'vcredist140', which, at the time of writing (sept 2022) is an outdated version from 2019: `14.22.27821.0`. I recommend installing chocolatey's `vcredist140` instead.
- * `/no-audio` - Do not install the audio driver.
- * `/no-usbc` - Do not install the USB-C driver.
+ * `/NoAudio` - Do not install the audio driver.
+ * `/NoUSBC` - Do not install the USB-C driver.
 
 Parameters can be passed to the script with the use of `--params`.
 For example: `--params "'/ShadowPlay /Nview'"`.

--- a/nvidia-display-driver/tools/chocolateyInstall.ps1
+++ b/nvidia-display-driver/tools/chocolateyInstall.ps1
@@ -50,10 +50,10 @@ Move-Item ($packageArgs['destination'] + "\GFExperience\PrivacyPolicy"      ) -D
 Move-Item ($packageArgs['destination'] + "\GFExperience\EULA.html"          ) -Destination "$instDir\GFExperience"
 Move-Item ($packageArgs['destination'] + "\GFExperience\FunctionalConsent_*") -Destination "$instDir\GFExperience"
 # I've changed my mind about not including the audio and USB-C driver by default.
-if ( -not $pp.no-audio ) {
+if ( -not $pp.NoAudio ) {
   Move-Item ($packageArgs['destination'] + "\HDAudio") -Destination "$instDir"
 }
-if ( -not $pp.no-usbc ) {
+if ( -not $pp.NoUSBC ) {
   Move-Item ($packageArgs['destination'] + "\PPC"    ) -Destination "$instDir" -ErrorAction SilentlyContinue
 }
 if ( $pp.NV3DVision ) {
@@ -81,4 +81,3 @@ Remove-Item ($packageArgs['destination']) -Recurse -Force
 $packageArgs['file'    ] = "$instDir\setup.exe"
 $packageArgs['fileType'] = 'EXE'
 Install-ChocolateyInstallPackage @packageArgs
-


### PR DESCRIPTION
chocolateyInstall.ps1 failing on upgrade due to unquoted property call on package parameters variable

Fixes #61