### PR TITLE
Remove Installer file only if it exists

### DIFF
--- a/wsltty/tools/chocolateyinstall.ps1
+++ b/wsltty/tools/chocolateyinstall.ps1
@@ -8,6 +8,14 @@ if (Get-OSArchitectureWidth -compare 64) {
 	$filePath = $filePath32
 }
 
+Function Remove-Installer($Installer){
+
+	if (-not [string]::IsNullOrEmpty("$Installer") -and (Test-Path "$Installer")) {
+		Remove-Item -Force -ea 0 "$Installer"
+	}
+
+}
+
 # Extract installer
 Start-Process -FilePath "$filePath" -ArgumentList "/T:$toolsDir\wslttyinstall /C /Q" -WorkingDirectory "$toolsdir" -Wait
 # Create shortcut
@@ -16,8 +24,8 @@ Install-ChocolateyShortcut `
  -TargetPath "$toolsDir\wslttyinstall\install.bat" `
  -WorkingDirectory "$toolsDir\wslttyinstall"
 # Remove installer
-Remove-Item -Force -ea 0 "$filePath32"
-Remove-Item -Force -ea 0 "$filePath64"
+Remove-Installer "$filePath32"
+Remove-Installer "$filePath64"
 # Generate *.exe.ignore
 gi "$toolsDir\wslttyinstall\*.exe" | % { New-Item "$($_.FullName).ignore" -type File }
 


### PR DESCRIPTION
Fixes #66 

The package doesn't include the 32-bit installer.

So, when `Remove-Item -Force -ea 0 "$filePath32"` is called, windows powershell errors out, because it ends up checking the path for an empty string.

This changes the package to remove the installer only when the filename variable is set and the path to it exists.

NOTE:
It's possible to instead simply remove everything that refers to 32-bit instead. But the way the PR changes things would allow for installation of the package were upstream to bring back 32-bit support.