### PR TITLE
Use latest Chocolatey

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,7 +53,7 @@ install:
 - ps: 'Get-CimInstance win32_operatingsystem -Property Caption, OSArchitecture, Version | fl Caption, OSArchitecture, Version'
 - ps: $PSVersionTable
 - git --version
-- choco --version
+- choco upgrade chocolatey -y
 - ps: |
     git clone -q https://github.com/majkinetor/au.git $Env:TEMP/au
     . "$Env:TEMP/au/scripts/Install-AU.ps1" $Env:au_version


### PR DESCRIPTION
This should resolve issues where packages were created with a 2-part version, but then choco tries to look up a 3-part version and it fails to resolve the package.

https://docs.chocolatey.org/en-us/choco/features/version-number-normalization/