### PR TITLE
(nvidia-display-driver) Fix package

### DIFF
--- a/nvidia-display-driver/nvidia-display-driver.nuspec
+++ b/nvidia-display-driver/nvidia-display-driver.nuspec
@@ -18,6 +18,7 @@
     <description>This package strips all components out of the upstream NVidia driver package except the following:
 
 - Display.Driver
+- NVApp
 - PhysX
 - HDAudio
 - USB-C driver

--- a/nvidia-display-driver/nvidia-display-driver.nuspec
+++ b/nvidia-display-driver/nvidia-display-driver.nuspec
@@ -30,6 +30,7 @@ The following package parameters can be set to enable optional components:
  * `/Nview` - Install RTX Desktop Manager.
  * `/ShadowPlay` - Install ShadowPlay.
  * `/FrameView` - Install FrameView.
+ * `/NVApp` - Install additional dependencies required by the NVIDIA app.
  * `/MSVCRT` - Install the nvidia-packaged 'vcredist140', which, at the time of writing (sept 2022) is an outdated version from 2019: `14.22.27821.0`. I recommend installing chocolatey's `vcredist140` instead.
  * `/NoAudio` - Do not install the audio driver.
  * `/NoUSBC` - Do not install the USB-C driver.

--- a/nvidia-display-driver/nvidia-display-driver.nuspec
+++ b/nvidia-display-driver/nvidia-display-driver.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nvidia-display-driver</id>
-    <version>566.36</version>
+    <version>566.36.0.20241208</version>
     <packageSourceUrl>https://github.com/AeliusSaionji/chocopkgs/tree/master/nvidia-display-driver</packageSourceUrl>
     <owners>Link Satonaka</owners>
     <title>NVidia Display Driver</title>

--- a/nvidia-display-driver/nvidia-display-driver.nuspec
+++ b/nvidia-display-driver/nvidia-display-driver.nuspec
@@ -42,7 +42,7 @@ To avoid confusion, DCH is now the default and only option.
 If you need support for non display related components (Shield, Geforce Experience, ...), install the unaltered `geforce-game-ready-driver` instead.
 
     </description>
-    <releaseNotes>https://us.download.nvidia.com/Windows/566.36/566.36-win11-win10-win8-win7-release-notes.pdf</releaseNotes>
+    <releaseNotes>https://us.download.nvidia.com/Windows/566.36/566.36-win11-win10-release-notes.pdf</releaseNotes>
     <dependencies>
         <dependency id="chocolatey-core.extension" version="1.1.0" />
     </dependencies>

--- a/nvidia-display-driver/nvidia-display-driver.nuspec
+++ b/nvidia-display-driver/nvidia-display-driver.nuspec
@@ -32,6 +32,7 @@ The following package parameters can be set to enable optional components:
  * `/FrameView` - Install FrameView.
  * `/NVApp` - Install additional dependencies required by the NVIDIA app.
  * `/MSVCRT` - Install the nvidia-packaged 'vcredist140', which, at the time of writing (sept 2022) is an outdated version from 2019: `14.22.27821.0`. I recommend installing chocolatey's `vcredist140` instead.
+ * `/NvDLISR` - Install NvDLISR.
  * `/NoAudio` - Do not install the audio driver.
  * `/NoUSBC` - Do not install the USB-C driver.
 

--- a/nvidia-display-driver/nvidia-display-driver.nuspec
+++ b/nvidia-display-driver/nvidia-display-driver.nuspec
@@ -18,7 +18,6 @@
     <description>This package strips all components out of the upstream NVidia driver package except the following:
 
 - Display.Driver
-- Display.Optimus
 - PhysX
 - HDAudio
 - USB-C driver

--- a/nvidia-display-driver/tools/chocolateyInstall.ps1
+++ b/nvidia-display-driver/tools/chocolateyInstall.ps1
@@ -55,6 +55,10 @@ if ( $pp.NV3DVision ) {
   Move-Item ($packageArgs['destination'] + "\NV3DVision"          ) -Destination "$instDir"
   Move-Item ($packageArgs['destination'] + "\NV3DVisionUSB.Driver") -Destination "$instDir"
 }
+if ( $pp.NVApp ) {
+  Move-Item ($packageArgs['destination'] + "\NVApp.MessageBus"    ) -Destination "$instDir"
+  Move-Item ($packageArgs['destination'] + "\NVCpl"               ) -Destination "$instDir"
+}
 # Misc new additions
 if ( $pp.Nview ) {
   Move-Item ($packageArgs['destination'] + "\Display.Nview") -Destination "$instDir"

--- a/nvidia-display-driver/tools/chocolateyInstall.ps1
+++ b/nvidia-display-driver/tools/chocolateyInstall.ps1
@@ -72,6 +72,9 @@ if ( $pp.FrameView ) {
 if ( $pp.MSVCRT ) {#MS VC Redist from 2019???
   Move-Item ($packageArgs['destination'] + "\MSVCRT") -Destination "$instDir"
 }
+if ( $pp.NvDLISR ) {
+  Move-Item ($packageArgs['destination'] + "\NvDLISR") -Destination "$instDir"
+}
 
 # Remove unused files
 Remove-Item ($packageArgs['destination']) -Recurse -Force

--- a/nvidia-display-driver/tools/chocolateyInstall.ps1
+++ b/nvidia-display-driver/tools/chocolateyInstall.ps1
@@ -26,7 +26,6 @@ If ( -not (Get-OSArchitectureWidth -compare 64) ) {
 # Remove any previous tempfiles
 Remove-Item "$instDir" -Recurse -Force -ea 0
 New-Item -Path "$instDir" -ItemType Directory
-New-Item -Path "$instDir\GFExperience" -ItemType Directory
 
 # Download driver package as a zip
 $packageArgs['file'] = "${ENV:TEMP}\nvidiadriver.zip"
@@ -37,7 +36,6 @@ Get-ChocolateyUnzip @packageArgs
 
 # Move everything we want to a new folder
 Move-Item ($packageArgs['destination'] + "\Display.Driver"        ) -Destination "$instDir"
-Move-Item ($packageArgs['destination'] + "\Display.Optimus"       ) -Destination "$instDir"
 Move-Item ($packageArgs['destination'] + "\NVI2"                  ) -Destination "$instDir"
 Move-Item ($packageArgs['destination'] + "\NVPCF"                 ) -Destination "$instDir"
 Move-Item ($packageArgs['destination'] + "\PhysX"                 ) -Destination "$instDir"
@@ -45,10 +43,6 @@ Move-Item ($packageArgs['destination'] + "\EULA.txt"              ) -Destination
 Move-Item ($packageArgs['destination'] + "\ListDevices.txt"       ) -Destination "$instDir"
 Move-Item ($packageArgs['destination'] + "\setup.cfg"             ) -Destination "$instDir"
 Move-Item ($packageArgs['destination'] + "\setup.exe"             ) -Destination "$instDir"
-# Must include these legal files to satisfy the installer. GFE will not be installed.
-Move-Item ($packageArgs['destination'] + "\GFExperience\PrivacyPolicy"      ) -Destination "$instDir\GFExperience"
-Move-Item ($packageArgs['destination'] + "\GFExperience\EULA.html"          ) -Destination "$instDir\GFExperience"
-Move-Item ($packageArgs['destination'] + "\GFExperience\FunctionalConsent_*") -Destination "$instDir\GFExperience"
 # I've changed my mind about not including the audio and USB-C driver by default.
 if ( -not $pp.NoAudio ) {
   Move-Item ($packageArgs['destination'] + "\HDAudio") -Destination "$instDir"

--- a/nvidia-display-driver/tools/chocolateyInstall.ps1
+++ b/nvidia-display-driver/tools/chocolateyInstall.ps1
@@ -36,6 +36,7 @@ Get-ChocolateyUnzip @packageArgs
 
 # Move everything we want to a new folder
 Move-Item ($packageArgs['destination'] + "\Display.Driver"        ) -Destination "$instDir"
+Move-Item ($packageArgs['destination'] + "\NVApp"                 ) -Destination "$instDir"
 Move-Item ($packageArgs['destination'] + "\NVI2"                  ) -Destination "$instDir"
 Move-Item ($packageArgs['destination'] + "\NVPCF"                 ) -Destination "$instDir"
 Move-Item ($packageArgs['destination'] + "\PhysX"                 ) -Destination "$instDir"

--- a/nvidia-display-driver/update.ps1
+++ b/nvidia-display-driver/update.ps1
@@ -13,7 +13,7 @@ function global:au_SearchReplace {
       "(?i)(^\s*[$]packageArgs\['checksum64'\]\s*=\s*)('.*')" = "`$1'$($Latest.Checksum7864)'"
     }
     ".\nvidia-display-driver.nuspec" = @{
-      "(?i)(^\s*<releaseNotes>)(.*)" = "`${1}https://us.download.nvidia.com/Windows/$($Latest.Version)/$($Latest.Version)-win11-win10-win8-win7-release-notes.pdf</releaseNotes>"
+      "(?i)(^\s*<releaseNotes>)(.*)" = "`${1}https://us.download.nvidia.com/Windows/$($Latest.Version)/$($Latest.Version)-win11-win10-release-notes.pdf</releaseNotes>"
     }
   }
 }


### PR DESCRIPTION
This PR aims to get `nvidia-display-driver` back into a working state.

v566.36 of the package is currently broken, due to the latest installer version having removed GeForce Experience in favor of the NVIDIA app:

```
ERROR: The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: Cannot find path 'C:\Users\brian\AppData\Local\Temp\chocolatey\nvidiadriver\Display.Optimus' because it does not exist.
The install of nvidia-display-driver was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\nvidia-display-driver\tools\chocolateyInstall.ps1'.
 See log for details.
```

Unfortunately, a silent installation seems to default to including the NVIDIA app, despite the option to exclude it being available when run non-silently:

![NVIDIA Installer screenshot](https://github.com/user-attachments/assets/8be28558-fff1-4ab1-a125-712ffcbeecfe)

As the installer will refuse to run without the `NvApp` directory being present, I've included it in a similar vein to some GeForce Experience files being historically included.

Some additional new components were also introduced (i.e., `NvApp`'s dependencies [`NvApp.MessageBus` and `NVCpl`], and `NvDLISR`), and have been exposed via a couple new package parameters.

I've also updated the package's `releaseNotes` URL to reflect a change in filename. The current URL is 404ing.