### PR TITLE
Check for Slack/Teams in OBS Studio installer

### DIFF
--- a/obs-studio.install/tools/chocolateyinstall.ps1
+++ b/obs-studio.install/tools/chocolateyinstall.ps1
@@ -2,6 +2,15 @@
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $file64Location = Get-Item $toolsDir\*_x64.exe
 
+# Check for running applications that may interfere with the installation
+if (Get-Process -Name ms-teams -ErrorAction SilentlyContinue) {
+  Write-Error "Please close Microsoft Teams before installing/updating OBS Studio."
+}
+
+if (Get-Process -Name Slack -ErrorAction SilentlyContinue) {
+  Write-Error "Please close Slack before installing/updating OBS Studio."
+}
+
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   fileType      = 'EXE'


### PR DESCRIPTION
Add checks in the obs-studio installer to ensure that Slack and Teams aren't running.

These are both known to interfere with the OBS installer (causing it to fail with a weird error 6).

There are probably other processes that could be checked for as well, but these are the two I've observed firsthand.