### PR TITLE
`geforce-game-ready-driver` - Update `releaseNotes` replacement pattern

### DIFF
--- a/geforce-game-ready-driver/update.ps1
+++ b/geforce-game-ready-driver/update.ps1
@@ -13,7 +13,7 @@ function global:au_SearchReplace {
       "(?i)(^\s*[$]packageArgs\['checksum64'\]\s*=\s*)('.*')" = "`$1'$($Latest.Checksum7864)'"
     }
     ".\geforce-game-ready-driver.nuspec" = @{
-      "(?i)(^\s*<releaseNotes>)(.*)" = "`${1}https://us.download.nvidia.com/Windows/$($Latest.Version)/$($Latest.Version)-win11-win10-win8-win7-release-notes.pdf</releaseNotes>"
+      "(?i)(^\s*<releaseNotes>)(.*)" = "`${1}https://us.download.nvidia.com/Windows/$($Latest.SoftwareVersion)/$($Latest.SoftwareVersion)-win11-win10-release-notes.pdf</releaseNotes>"
     }
   }
 }
@@ -45,9 +45,10 @@ function global:au_GetLatest {
   $url7864  = $rest7864.IDS[0].downloadInfo.DownloadURL
 
   return @{
-    Version = $version
-    URL64   = $url64
-    URL7864 = $url7864
+    SoftwareVersion = $version
+    Version         = $version
+    URL64           = $url64
+    URL7864         = $url7864
   }
 }
 


### PR DESCRIPTION
The `releaseNotes` URL has been incorrect since v471.68, and requires an update to use the current filename.

Tested locally by forcing a package update with `au` via `.\update_all.ps1 -Name geforce-game-ready-driver -ForcedPackages geforce-game-ready-driver`, then verifying the resulting URL as written to the Nuspec.

This exposed another issue in that the replacement pattern uses the package version for the URL, which will not always equate to the software version, and results in an incorrect value for forced package updates. Resolved by copying the originally detected version to a separate variable (`SoftwareVersion`), which should not be overwritten in a forced update scenario.