### PR TITLE
Geforce Game Ready Driver 591.86

### DIFF
--- a/geforce-game-ready-driver/geforce-game-ready-driver.nuspec
+++ b/geforce-game-ready-driver/geforce-game-ready-driver.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>geforce-game-ready-driver</id>
-    <version>581.80</version>
+    <version>591.86</version>
     <packageSourceUrl>https://github.com/AeliusSaionji/chocopkgs/tree/master/geforce-game-ready-driver</packageSourceUrl>
     <owners>Link Satonaka</owners>
     <title>Geforce Game Ready Driver</title>
@@ -26,7 +26,7 @@ To avoid confusion, DCH is now the default and only option.
 
 Please refer to the release notes below or check nvidia.com to see which cards are no longer supported.
     </description>
-    <releaseNotes>https://us.download.nvidia.com/Windows/581.80/581.80-win11-win10-release-notes.pdf</releaseNotes>
+    <releaseNotes>https://us.download.nvidia.com/Windows/591.86/591.86-win11-win10-release-notes.pdf</releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/geforce-game-ready-driver/tools/chocolateyInstall.ps1
+++ b/geforce-game-ready-driver/tools/chocolateyInstall.ps1
@@ -2,8 +2,8 @@
 $packageArgs = @{
   packageName    = 'geforce-game-ready-driver'
   fileType       = 'EXE'
-  url64          = 'https://us.download.nvidia.com/Windows/581.80/581.80-desktop-win10-win11-64bit-international-dch-whql.exe'
-  checksum64     = '0a08462764f4d36eeecb8da6abfc01a6e32c94359b9e1e3287399f057c1d2839'
+  url64          = 'https://us.download.nvidia.com/Windows/591.86/591.86-desktop-win10-win11-64bit-international-dch-whql.exe'
+  checksum64     = 'a50c89c9d254f33cc8a8e638f7cc1981a76263005fcec102ad8c8b45626d53e0'
   checksumType64 = 'sha256'
   silentArgs     = '-s -noreboot'
   validExitCodes = @(0,1)


### PR DESCRIPTION
Update the driver for the latest geforce-game-ready 591.86 so it can be pushed to chocolatey pkgs