### PR TITLE
wsltty: Add note about VirusTotal false positives

### DIFF
--- a/wsltty/wsltty.nuspec
+++ b/wsltty/wsltty.nuspec
@@ -16,8 +16,12 @@
     <bugTrackerUrl>https://github.com/mintty/wsltty/issues</bugTrackerUrl>
     <tags>wsltty mintty wsl cygwin linux</tags>
     <summary>Mintty as a terminal for Windows Subsystem for Linux / WSL.</summary>
-    <description>Mintty as a terminal for WSL (Windows Subsystem for Linux).  
-	    This package installs wsltty such that it is available to all users on the system.</description>
+    <description>
+      Mintty as a terminal for WSL (Windows Subsystem for Linux).  
+      This package installs wsltty such that it is available to all users on the system.
+
+      The installer for mintty uses iexpress.exe which is prone to false-positive VirusTotal detections.  Details are tracked in [this upstream issue](https://github.com/mintty/wsltty/issues/345).
+    </description>
     <releaseNotes>https://github.com/mintty/wsltty/releases/latest</releaseNotes>
     <!--<dependencies>
     </dependencies>-->


### PR DESCRIPTION
Also link to the upstream issue discussing the problem.  This seems like what the Chocolatey reviewer wanted:

> Does the underlying application have any known issues with high virus
> detections? If so, can you add some information to the description for
> this package, so that the higher than normal detections can be
> explained? Thanks

Hopefully this resolves this going forward...

I wasn't quite sure how you'd prefer to format the description in the nuspec, I checked a few others and saw a variety of styles.  Please feel free to update it to however you would like it.  I saw [here](https://docs.chocolatey.org/en-us/create/create-packages/#package-description-and-release-notes) that Markdown should work.