### PR TITLE
WSLTTY: update update.ps1 and tools/VERIFICATION.txt

### DIFF
--- a/wsltty/tools/VERIFICATION.txt
+++ b/wsltty/tools/VERIFICATION.txt
@@ -8,7 +8,7 @@ and can be verified by doing the following:
 
 1. Go to
 
-	x64: https://github.com/mintty/wsltty/releases/download/3.8.0.3/wsltty-3.8.0.3-x86_64-install-portable.exe
+	x64: https://github.com/mintty/wsltty/releases/download/3.8.0.3/wsltty-3.8.0.3-x86_64-install-quiet.exe
 
 	to download the installer.
 
@@ -19,7 +19,7 @@ and can be verified by doing the following:
 3. The checksums should match the following:
 
   checksumType: sha256
-  checksum64: 8BB2CFEE03E6504207F6A0D0AAD81BB453F4CABBF78A3F91D61E570A7F50BE12
+  checksum64: 473D25F2416BF6B01B1BA9BA8853F15DD2F2F3480F576BCEF35480414119D68A
 
 The files 'LICENSE.mintty.txt' 'LICENSE.txt' have been obtained from <https://github.com/mintty/wsltty/blob/master/LICENSE.wslbridge>
 <https://github.com/mintty/wsltty/blob/master/LICENSE.mintty>

--- a/wsltty/update.ps1
+++ b/wsltty/update.ps1
@@ -26,7 +26,7 @@ function global:au_GetLatest {
   $restAPI.tag_name -match '(\d+\.?)+'
   $version = $Matches[0]
   $url64 = $restAPI.assets | Where-Object { ($_.content_type -eq 'application/x-msdownload') `
-    -and ($_.name -like '*x86_64*') } `
+    -and ($_.name -like '*x86_64*') -and ($_.name -like '*quiet*') } `
     | Select-Object -First 1 -ExpandProperty browser_download_url
 
 


### PR DESCRIPTION
This changes update.ps1 and VERIFICATION.txt to use the "quiet" wsltty installer.

Currently, the au_GetLatest function gets a list of x86_64 installer files in the github release section, then returns the first one to be installed.

Which results in using "wsltty-3.8.0.3-x86_64-install-portable.exe", because it's the first one listed in the releases section

But the wsltty-3.8.0.3-x86_64-install-portable.exe is (erroneously) detected as malware by some virus/malware scanners. On my work computers, when I download that file, it gets deleted automatically by a malware scanner my employer requires.

This update makes it use the wsltty-3.8.0.3-x86_64-install-quiet.exe installer instead, which doesn't suffer from the same issue; on my systems, it installs/runs perfectly and doesn't get removed by scanners unlike the above.