### PR TITLE
obs-studio: update to 32.2.2

### DIFF
--- a/obs-studio.install/obs-studio.install.nuspec
+++ b/obs-studio.install/obs-studio.install.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>obs-studio.install</id>
-    <version>32.1.2</version>
+    <version>32.2.2</version>
     <packageSourceUrl>https://github.com/AeliusSaionji/chocopkgs/tree/master/obs-studio.install</packageSourceUrl>
     <owners>LinkSatonaka</owners>
     <title>OBS Studio (Install)</title>

--- a/obs-studio.install/tools/VERIFICATION.txt
+++ b/obs-studio.install/tools/VERIFICATION.txt
@@ -3,7 +3,7 @@ Verification is intended to assist the Chocolatey moderators and community
 in verifying that this package's contents are trustworthy.
 
 Upstream URLs
-  x64: https://github.com/obsproject/obs-studio/releases/download/32.1.2/OBS-Studio-32.1.2-Windows-x64-Installer.exe
+  x64: https://github.com/obsproject/obs-studio/releases/download/32.2.2/OBS-Studio-32.2.2-Windows-x64-Installer.exe
 Checksums of embedded binaries
   checksumtype: sha256
-  checksum64: 94D180C1FC481CCC307B95513F795D088D63AC4F61AD3253C2AC0D94D0844110
+  checksum64: C3A0B880ADBE64DC4BCB68F93016916AB5B55AE43FD227115287BF80257D92DC

--- a/obs-studio.install/update.ps1
+++ b/obs-studio.install/update.ps1
@@ -24,7 +24,7 @@ function global:au_GetLatest {
   $Matches = $null
   $restAPI.tag_name -match '(\d+\.?)+'
   $version = $Matches[0]
-  $url64 = $restAPI.assets | Where-Object { ($_.content_type -eq 'application/octet-stream') `
+  $url64 = $restAPI.assets | Where-Object { ($_.content_type -eq 'application/x-msdos-program') `
     -and ($_.name -match 'Installer') `
     -and ($_.name -match 'Windows') } `
     | Select-Object -First 1 -ExpandProperty browser_download_url

--- a/obs-studio/obs-studio.nuspec
+++ b/obs-studio/obs-studio.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>obs-studio</id>
-    <version>32.1.2</version>
+    <version>32.2.2</version>
     <packageSourceUrl>https://github.com/AeliusSaionji/chocopkgs/tree/master/obs-studio</packageSourceUrl>
     <owners>LinkSatonaka</owners>
     <title>OBS Studio</title>
@@ -55,7 +55,7 @@ Browse or submit your own in the [Resources section](https://obsproject.com/foru
 	</description>
     <releaseNotes>https://github.com/obsproject/obs-studio/releases/latest</releaseNotes>
     <dependencies>
-      <dependency id="obs-studio.install" version="32.1.2" />
+      <dependency id="obs-studio.install" version="32.2.2" />
     </dependencies>
     <!--<provides>NOT YET IMPLEMENTED</provides>-->
     <!--<conflicts>NOT YET IMPLEMENTED</conflicts>-->


### PR DESCRIPTION
Update `obs-studio.install\update.ps1` for the Windows installer MIME type change.
The previous content type check caused the script to fail; corrected to `application/x-msdos-program`.